### PR TITLE
Expand investment data gathering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ This will run a few sample queries through the FinLife Navigator graph.
 ### Plaid Integration
 
 If `PLAID_CLIENT_ID`, `PLAID_SECRET`, and `ACCESS_TOKEN` are provided, the
-`InvestmentAgent` will fetch your sandbox account balance via Plaid when a
-query explicitly confirms an investment action (e.g. "invest now"). The
-projected balance after allocation is included in the response.
+`InvestmentAgent` can pull real account data via Plaid when the query requests it.
+Set `include_holdings` or `include_expenses` in the context (or mention them in
+the prompt) to fetch investment holdings and summarize recurring expenses. These
+values are used to validate that any suggested allocation is affordable.
+The account balance is still fetched when a user confirms an investment action
+(e.g. "invest now").

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ the prompt) to fetch investment holdings and summarize recurring expenses. These
 values are used to validate that any suggested allocation is affordable.
 The account balance is still fetched when a user confirms an investment action
 (e.g. "invest now").
+
+### Context Flags for `InvestmentAgent`
+
+You can influence how the investment agent gathers data and tailors
+recommendations by supplying optional keys in the `context` object or by
+mentioning them in your prompt:
+
+- `risk_tolerance`: `low`, `medium`, or `high` (defaults to `medium`)
+- `timeframe`: a tuple like `["5", "year"]` describing your horizon
+- `goal`: e.g. `retirement`, `buy_home`, or `emergency_fund`
+- `include_holdings`: set to `true` to fetch your existing investments
+- `include_expenses`: set to `true` to analyze recurring expenses
+- `override_fixed_expenses`: dictionary mapping expense names to amounts
+
+These inputs allow the agent to compute an appropriate allocation and ensure it
+fits your actual cash flow.

--- a/agents/investment_agent.py
+++ b/agents/investment_agent.py
@@ -7,7 +7,13 @@ then projects the balance after the suggested allocation."""
 from typing import Dict, Any
 import os
 from .openai_utils import generate_response
-from .plaid_service import fetch_account_balance
+from datetime import date, timedelta
+from .plaid_service import (
+    fetch_account_balance,
+    fetch_investment_holdings,
+    fetch_recent_transactions,
+    summarize_recurring_expenses,
+)
 
 
 class InvestmentAgent:
@@ -18,37 +24,120 @@ class InvestmentAgent:
         amount_str = context.get("amount")
         execute_plaid = context.get("execute_plaid", False)
 
+        risk = context.get("risk_tolerance", "medium")
+        goal = context.get("goal")
+        esg = context.get("esg", False)
+        timeframe = context.get("timeframe")
+        include_holdings = context.get("include_holdings", False)
+        include_expenses = context.get("include_expenses", False)
+        override_fixed_expenses = context.get("override_fixed_expenses", {}) or {}
+
         access_token = os.getenv("ACCESS_TOKEN") if execute_plaid else None
         starting_balance = fetch_account_balance(access_token) if access_token else None
+        holdings = fetch_investment_holdings(access_token) if (access_token and include_holdings) else None
+
+        fixed_expenses = {}
+        if access_token and include_expenses:
+            end_date = date.today()
+            start_date = end_date - timedelta(days=90)
+            txns = fetch_recent_transactions(access_token, start_date.isoformat(), end_date.isoformat())
+            fixed_expenses = summarize_recurring_expenses(txns)
+            fixed_expenses.update(override_fixed_expenses)
 
         try:
             amount = float(amount_str) if amount_str else None
         except ValueError:
             amount = None
 
-        if amount is not None:
-            stocks = amount * 0.6
-            bonds = amount * 0.3
-            cash = amount - stocks - bonds
+        available_amount = amount
+        total_fixed = sum(fixed_expenses.values()) if include_expenses else 0.0
+        if amount is not None and include_expenses:
+            available_amount = max(0.0, amount - total_fixed)
+
+        # Determine time horizon in years if provided
+        horizon = None
+        if timeframe and timeframe[1].startswith("year"):
+            try:
+                horizon = int(timeframe[0])
+            except (ValueError, TypeError):
+                horizon = None
+
+        # Dynamic allocation based on risk tolerance and time horizon
+        risk_map = {"low": 0.4, "medium": 0.6, "high": 0.8}
+        risk_score = risk_map.get(risk, 0.6)
+        time_score = min(horizon / 30, 1.0) if horizon else 0.5
+        stock_pct = 0.3 + 0.6 * (0.5 * risk_score + 0.5 * time_score)
+        cash_pct = 0.1 if horizon and horizon < 5 else 0.05
+        bond_pct = max(0.0, 1.0 - stock_pct - cash_pct)
+
+        if available_amount is not None:
+            stocks = available_amount * stock_pct
+            bonds = available_amount * bond_pct
+            cash = available_amount * cash_pct
+
             base = (
                 f"Invest ${stocks:.2f} in stocks, ${bonds:.2f} in bonds, and "
                 f"keep ${cash:.2f} in cash or equivalents."
             )
+            if include_expenses and total_fixed > 0:
+                base += (
+                    f" After reserving ${total_fixed:.2f} for recurring expenses,"
+                    f" ${available_amount:.2f} remains to invest."
+                )
 
             if execute_plaid and starting_balance is not None:
-                projected = starting_balance + amount
+                projected = starting_balance + available_amount
                 base += f" Your new balance could be around ${projected:.2f}."
+
+            # Simple growth projections
+            projections = {}
+            for yrs in [5, 10, 20]:
+                total = (
+                    stocks * ((1 + 0.07) ** yrs)
+                    + bonds * ((1 + 0.03) ** yrs)
+                    + cash * ((1 + 0.02) ** yrs)
+                )
+                if starting_balance is not None:
+                    total += starting_balance
+                projections[yrs] = total
+
+            proj_str = ", ".join(
+                [f"${projections[y]:.2f} in {y}y" for y in [5, 10, 20]]
+            )
+            base += f" Potential growth: {proj_str}."
+
+            if esg:
+                base += " ESG preferences noted."
+
+            if goal:
+                base = f"Goal: {goal}. " + base
 
             result = generate_response(
                 f"Provide a short investment suggestion based on: {base}"
             )
         else:
-            base = "Recommend 60% stocks, 30% bonds and 10% cash for a balanced portfolio."
+            base = (
+                f"Allocate {stock_pct*100:.0f}% stocks, {bond_pct*100:.0f}% bonds"
+                f" and {cash_pct*100:.0f}% cash for a diversified portfolio."
+            )
             result = generate_response(base)
 
-        metadata = {"amount": amount}
+        metadata = {
+            "amount": amount,
+            "available_amount": available_amount,
+            "risk": risk,
+            "goal": goal,
+            "horizon": horizon,
+            "stock_pct": stock_pct,
+            "bond_pct": bond_pct,
+            "cash_pct": cash_pct,
+        }
         if starting_balance is not None:
             metadata["starting_balance"] = starting_balance
+        if holdings is not None:
+            metadata["holdings"] = holdings
+        if fixed_expenses:
+            metadata["fixed_expenses"] = fixed_expenses
 
         return {
             "result": result,

--- a/agents/plaid_service.py
+++ b/agents/plaid_service.py
@@ -3,6 +3,9 @@ from typing import Optional
 from plaid.api import plaid_api
 from plaid import Configuration, ApiClient
 from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
+from plaid.model.investments_holdings_get_request import InvestmentsHoldingsGetRequest
+from plaid.model.transactions_get_request import TransactionsGetRequest
+from plaid.model.transactions_get_request_options import TransactionsGetRequestOptions
 
 
 def get_client() -> Optional[plaid_api.PlaidApi]:
@@ -28,3 +31,79 @@ def fetch_account_balance(access_token: str) -> Optional[float]:
         return accounts[0]["balances"].get("available") or accounts[0]["balances"].get("current")
     except Exception:
         return None
+
+
+def fetch_investment_holdings(access_token: str):
+    """Retrieve current investment positions with market value."""
+    client = get_client()
+    if not client:
+        return None
+    try:
+        request = InvestmentsHoldingsGetRequest(access_token=access_token)
+        response = client.investments_holdings_get(request)
+        holdings = []
+        securities = {s["security_id"]: s for s in response.get("securities", [])}
+        for h in response.get("holdings", []):
+            sec = securities.get(h.get("security_id"), {})
+            holdings.append({
+                "ticker": sec.get("ticker_symbol"),
+                "quantity": h.get("quantity"),
+                "market_value": h.get("institution_value"),
+            })
+        return holdings
+    except Exception:
+        return None
+
+
+def fetch_recent_transactions(access_token: str, start_date: str, end_date: str):
+    """Fetch raw transactions within a date range."""
+    client = get_client()
+    if not client:
+        return None
+    try:
+        request = TransactionsGetRequest(
+            access_token=access_token,
+            start_date=start_date,
+            end_date=end_date,
+            options=TransactionsGetRequestOptions(count=500, offset=0),
+        )
+        response = client.transactions_get(request)
+        return response.get("transactions", [])
+    except Exception:
+        return None
+
+
+def summarize_recurring_expenses(transactions):
+    """Summarize recurring monthly expenses from transaction data."""
+    from collections import defaultdict
+    from datetime import datetime
+    import statistics
+
+    if not transactions:
+        return {}
+
+    groups = defaultdict(list)
+    for txn in transactions:
+        name = txn.get("name")
+        amount = txn.get("amount")
+        date_str = txn.get("date")
+        if not (name and amount and date_str):
+            continue
+        groups[name].append((amount, date_str))
+
+    recurring = {}
+    for name, entries in groups.items():
+        if len(entries) < 2:
+            continue
+        # sort by date
+        entries.sort(key=lambda x: x[1])
+        dates = [datetime.fromisoformat(d) for _, d in entries]
+        diffs = [abs((dates[i] - dates[i-1]).days) for i in range(1, len(dates))]
+        if not diffs:
+            continue
+        avg_diff = sum(diffs) / len(diffs)
+        if 25 <= avg_diff <= 35:
+            amounts = [amt for amt, _ in entries]
+            recurring[name] = round(statistics.mean(amounts), 2)
+
+    return recurring

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -76,7 +76,39 @@ class PlannerAgent:
         time_matches = re.findall(time_pattern, user_input, re.IGNORECASE)
         if time_matches:
             context["timeframe"] = time_matches[0]
-        
+
+        # Risk tolerance
+        if re.search(r"low risk|conservative|cautious", user_input, re.IGNORECASE):
+            context["risk_tolerance"] = "low"
+        elif re.search(r"medium risk|moderate", user_input, re.IGNORECASE):
+            context["risk_tolerance"] = "medium"
+        elif re.search(r"high risk|aggressive", user_input, re.IGNORECASE):
+            context["risk_tolerance"] = "high"
+
+        # Investment goals
+        if re.search(r"retire|retirement", user_input, re.IGNORECASE):
+            context["goal"] = "retirement"
+        elif re.search(r"house|home|down payment", user_input, re.IGNORECASE):
+            context["goal"] = "buy_home"
+        elif re.search(r"emergency fund|rainy day|safety net", user_input, re.IGNORECASE):
+            context["goal"] = "emergency_fund"
+
+        # ESG preference
+        if re.search(r"esg|ethical|sustainable|socially responsible|green", user_input, re.IGNORECASE):
+            context["esg"] = True
+
+        if "current holdings" in user_input or "existing portfolio" in user_input:
+            context["include_holdings"] = True
+        if "expenses" in user_input or "bills" in user_input:
+            context["include_expenses"] = True
+
+        override_pattern = r"(rent|utilities|mortgage|subscription)\s*\$?(\d+(?:,\d{3})*(?:\.\d{2})?)"
+        overrides = re.findall(override_pattern, user_input, re.IGNORECASE)
+        if overrides:
+            context["override_fixed_expenses"] = {
+                name.capitalize(): float(value.replace(",", "")) for name, value in overrides
+            }
+
 
         # Determine if multiple agents might be needed
         if len([qt for qt in self.query_patterns.keys()


### PR DESCRIPTION
## Summary
- pull investment holdings and recurring expenses from Plaid
- let Planner set `include_holdings` and `include_expenses` with overrides
- factor recurring expenses into allocation logic
- document Plaid context options in README

## Testing
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_684348d24c0883328c0e9fc436a62f11