### PR TITLE
Enhance plaid features and planning logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ If `PLAID_CLIENT_ID`, `PLAID_SECRET`, and `ACCESS_TOKEN` are provided, the
 `InvestmentAgent` will fetch your sandbox account balance via Plaid when a
 query explicitly confirms an investment action (e.g. "invest now"). The
 projected balance after allocation is included in the response.
+
+When `include_holdings` or `include_expenses` is set in the context the agent
+will pull investment positions and recent transactions. Recurring expenses are
+summarized to estimate available cash flow for new contributions.

--- a/agents/finance_utils.py
+++ b/agents/finance_utils.py
@@ -1,0 +1,47 @@
+from collections import defaultdict
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+
+def summarize_recurring_expenses(transactions: Optional[List[Dict[str, Any]]]) -> Dict[str, float]:
+    """Return average monthly cost for recurring payees."""
+    recurring = {}
+    if not transactions:
+        return recurring
+    grouped = defaultdict(list)
+    for tx in transactions:
+        name = tx.get("name")
+        if not name:
+            continue
+        amount = abs(tx.get("amount", 0))
+        date = tx.get("date")
+        if not date:
+            continue
+        grouped[name].append((date, amount))
+    for name, entries in grouped.items():
+        months = defaultdict(float)
+        for date, amount in entries:
+            month = date[:7]
+            months[month] += amount
+        if len(months) >= 2:
+            avg = sum(months.values()) / len(months)
+            recurring[name] = avg
+    return recurring
+
+
+def derive_monthly_income(transactions: Optional[List[Dict[str, Any]]]) -> float:
+    """Estimate average monthly income from positive transactions."""
+    if not transactions:
+        return 0.0
+    monthly = defaultdict(float)
+    for tx in transactions:
+        amount = tx.get("amount", 0)
+        if amount > 0:
+            date = tx.get("date")
+            if not date:
+                continue
+            month = date[:7]
+            monthly[month] += amount
+    if not monthly:
+        return 0.0
+    return sum(monthly.values()) / len(monthly)

--- a/agents/investment_agent.py
+++ b/agents/investment_agent.py
@@ -1,13 +1,20 @@
-"""Simple investment strategy generation.
+"""Investment portfolio recommendation logic.
 
-This agent optionally uses the Plaid API in sandbox mode to fetch the
-current account balance when the user confirms an investment action. It
-then projects the balance after the suggested allocation."""
+This agent can optionally pull account balance, holdings, and recent
+transactions using Plaid. When holdings and expenses are provided it
+calculates available cash flow and adjusts recommendations to account
+for existing assets."""
 
 from typing import Dict, Any
 import os
 from .openai_utils import generate_response
-from .plaid_service import fetch_account_balance
+from datetime import datetime, timedelta
+from .plaid_service import (
+    fetch_account_balance,
+    fetch_investment_holdings,
+    fetch_recent_transactions,
+)
+from .finance_utils import summarize_recurring_expenses, derive_monthly_income
 
 
 class InvestmentAgent:
@@ -17,6 +24,9 @@ class InvestmentAgent:
         context = state.get("context", {}) or {}
         amount_str = context.get("amount")
         execute_plaid = context.get("execute_plaid", False)
+        include_holdings = context.get("include_holdings", False)
+        include_expenses = context.get("include_expenses", False)
+        override_expenses = context.get("override_fixed_expenses", {}) or {}
 
         risk = context.get("risk_tolerance", "medium")
         goal = context.get("goal")
@@ -25,6 +35,21 @@ class InvestmentAgent:
 
         access_token = os.getenv("ACCESS_TOKEN") if execute_plaid else None
         starting_balance = fetch_account_balance(access_token) if access_token else None
+        current_holdings = fetch_investment_holdings(access_token) if access_token and include_holdings else []
+
+        transactions = []
+        if access_token and include_expenses:
+            end_date = datetime.utcnow().date()
+            start_date = end_date - timedelta(days=90)
+            transactions = fetch_recent_transactions(
+                access_token, start_date.isoformat(), end_date.isoformat()
+            ) or []
+        fixed_expenses = summarize_recurring_expenses(transactions)
+        fixed_expenses.update(override_expenses)
+        monthly_income = derive_monthly_income(transactions)
+        available_for_investment = (
+            monthly_income - sum(fixed_expenses.values()) if monthly_income else None
+        )
 
         try:
             amount = float(amount_str) if amount_str else None
@@ -46,6 +71,26 @@ class InvestmentAgent:
         stock_pct = 0.3 + 0.6 * (0.5 * risk_score + 0.5 * time_score)
         cash_pct = 0.1 if horizon and horizon < 5 else 0.05
         bond_pct = max(0.0, 1.0 - stock_pct - cash_pct)
+
+        # Compute portfolio context if holdings are available
+        total_portfolio_value = (
+            (starting_balance or 0) + sum(h.get("market_value", 0) for h in current_holdings)
+        )
+        current_stock_value = sum(
+            h.get("market_value", 0)
+            for h in current_holdings
+            if str(h.get("type")).lower() in ["equity", "etf", "stock"]
+        )
+        current_bond_value = sum(
+            h.get("market_value", 0) for h in current_holdings if str(h.get("type")).lower() == "bond"
+        )
+        current_cash_value = starting_balance or 0
+        current_stock_pct = current_stock_value / total_portfolio_value if total_portfolio_value else 0
+        current_bond_pct = current_bond_value / total_portfolio_value if total_portfolio_value else 0
+        current_cash_pct = current_cash_value / total_portfolio_value if total_portfolio_value else 0
+
+        stock_deficit = max(0.0, stock_pct - current_stock_pct) * total_portfolio_value
+        bond_deficit = max(0.0, bond_pct - current_bond_pct) * total_portfolio_value
 
         if amount is not None:
             stocks = amount * stock_pct
@@ -87,6 +132,27 @@ class InvestmentAgent:
             result = generate_response(
                 f"Provide a short investment suggestion based on: {base}"
             )
+        elif available_for_investment is not None:
+            stocks = available_for_investment * stock_pct
+            bonds = available_for_investment * bond_pct
+            cash = available_for_investment * cash_pct
+            base = (
+                f"Each month invest ${stocks:.2f} in stocks, ${bonds:.2f} in bonds, "
+                f"and keep ${cash:.2f} in cash from your available funds."
+            )
+            if current_holdings:
+                base += (
+                    f" Your portfolio is currently {current_stock_pct*100:.0f}% stocks, "
+                    f"{current_bond_pct*100:.0f}% bonds, {current_cash_pct*100:.0f}% cash."
+                )
+                base += (
+                    f" To reach the target {stock_pct*100:.0f}/{bond_pct*100:.0f}/{cash_pct*100:.0f}, "
+                    f"direct new contributions toward ${stock_deficit:.2f} in stocks "
+                    f"and ${bond_deficit:.2f} in bonds."
+                )
+            result = generate_response(
+                f"Provide a short investment suggestion based on: {base}"
+            )
         else:
             base = (
                 f"Allocate {stock_pct*100:.0f}% stocks, {bond_pct*100:.0f}% bonds"
@@ -102,6 +168,10 @@ class InvestmentAgent:
             "stock_pct": stock_pct,
             "bond_pct": bond_pct,
             "cash_pct": cash_pct,
+            "holdings": current_holdings,
+            "fixed_expenses": fixed_expenses,
+            "monthly_income": monthly_income,
+            "available_for_investment": available_for_investment,
         }
         if starting_balance is not None:
             metadata["starting_balance"] = starting_balance

--- a/agents/plaid_service.py
+++ b/agents/plaid_service.py
@@ -1,8 +1,10 @@
 import os
-from typing import Optional
+from typing import Optional, List, Dict, Any
 from plaid.api import plaid_api
 from plaid import Configuration, ApiClient
 from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
+from plaid.model.investments_holdings_get_request import InvestmentsHoldingsGetRequest
+from plaid.model.transactions_get_request import TransactionsGetRequest
 
 
 def get_client() -> Optional[plaid_api.PlaidApi]:
@@ -26,5 +28,51 @@ def fetch_account_balance(access_token: str) -> Optional[float]:
         if not accounts:
             return None
         return accounts[0]["balances"].get("available") or accounts[0]["balances"].get("current")
+    except Exception:
+        return None
+
+
+def fetch_investment_holdings(access_token: str) -> Optional[List[Dict[str, Any]]]:
+    """Return simplified holdings information for the given access token."""
+    client = get_client()
+    if not client:
+        return None
+    try:
+        request = InvestmentsHoldingsGetRequest(access_token=access_token)
+        response = client.investments_holdings_get(request)
+        holdings = []
+        securities = {s["security_id"]: s for s in response.get("securities", [])}
+        for h in response.get("holdings", []):
+            sec = securities.get(h.get("security_id"), {})
+            quantity = h.get("quantity") or 0
+            price = h.get("institution_price") or 0
+            holdings.append({
+                "ticker": sec.get("ticker_symbol"),
+                "quantity": quantity,
+                "market_value": quantity * price,
+                "type": sec.get("type")
+            })
+        return holdings
+    except Exception:
+        return None
+
+
+def fetch_recent_transactions(access_token: str, start_date: str, end_date: str) -> Optional[List[Dict[str, Any]]]:
+    """Fetch recent transactions within the date range."""
+    client = get_client()
+    if not client:
+        return None
+    try:
+        request = TransactionsGetRequest(access_token=access_token, start_date=start_date, end_date=end_date)
+        response = client.transactions_get(request)
+        txs = []
+        for tx in response.get("transactions", []):
+            txs.append({
+                "name": tx.get("name"),
+                "amount": tx.get("amount"),
+                "date": tx.get("date"),
+                "category": tx.get("category")
+            })
+        return txs
     except Exception:
         return None

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -97,6 +97,21 @@ class PlannerAgent:
         if re.search(r"esg|ethical|sustainable|socially responsible|green", user_input, re.IGNORECASE):
             context["esg"] = True
 
+        # Include holdings or expenses based on keywords
+        if re.search(r"holdings|portfolio|existing investments", user_input, re.IGNORECASE):
+            context["include_holdings"] = True
+        if re.search(r"expenses|recurring bills|fixed costs", user_input, re.IGNORECASE):
+            context["include_expenses"] = True
+
+        # Simple overrides for common expenses
+        overrides = {}
+        for name in ["rent", "utilities"]:
+            match = re.search(fr"{name}\s*\$?(\d+(?:,\d{3})*(?:\.\d+)?)", user_input, re.IGNORECASE)
+            if match:
+                overrides[name.capitalize()] = float(match.group(1).replace(",", ""))
+        if overrides:
+            context["override_fixed_expenses"] = overrides
+
 
         # Determine if multiple agents might be needed
         if len([qt for qt in self.query_patterns.keys()


### PR DESCRIPTION
## Summary
- expand Plaid service with holdings and transactions helpers
- add utility functions to analyze recurring expenses and income
- update planner to capture holdings/expenses requests
- extend investment agent to consider cash flow and existing assets
- document new context fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plaid')*

------
https://chatgpt.com/codex/tasks/task_e_6843846e008c8332b9abaea8b2a89dfa