### PR TITLE
Use OpenAI for smarter agent responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ python main.py
 
 This will run a few sample queries through the FinLife Navigator graph.
 
+### Interactive CLI
+
+To try a quick interactive session with a basic user profile, run:
+
+```bash
+python cli.py
+```
+
+The script collects a few onboarding details (risk tolerance, goal, time
+horizon) and then lets you type questions until you enter `exit`.
+
 ### Plaid Integration
 
 If `PLAID_CLIENT_ID`, `PLAID_SECRET`, and `ACCESS_TOKEN` are provided, the

--- a/agents/LifeEventAgent.py
+++ b/agents/LifeEventAgent.py
@@ -1,40 +1,29 @@
 """Simple logic for handling major life events."""
 
 from typing import Dict, Any
+from .openai_utils import generate_response
 
 
 class LifeEventAgent:
     """Processes life events found in the user input."""
 
-    LIFE_EVENTS = [
-        "vacation",
-        "wedding",
-        "baby",
-        "house",
-        "car",
-        "moving",
-        "retirement",
-    ]
-
     def process(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """Return a short plan for the detected life event."""
 
-        user_input = state.get("input", "").lower()
+        user_input = state.get("input", "")
         context = state.get("context", {}) or {}
-        amount = context.get("amount")
 
-        event = next((e for e in self.LIFE_EVENTS if e in user_input), None)
-
-        if event:
-            base = f"Plan created for upcoming {event}."
-        else:
-            base = "General life event plan created."
-
-        if amount:
-            base += f" Estimated budget: ${amount}."
+        prompt = (
+            "You are a helpful financial assistant. Provide a concise plan or "
+            "set of tips for the following user request. If a specific life "
+            "event is mentioned, tailor the advice accordingly. Limit the "
+            "response to no more than three sentences.\nRequest: "
+            f"{user_input}\nContext: {context}"
+        )
+        result = generate_response(prompt, max_tokens=100)
 
         return {
-            "result": base,
-            "confidence_score": 0.85 if event else 0.6,
-            "metadata": {"event": event, "amount": amount},
+            "result": result,
+            "confidence_score": 0.85,
+            "metadata": {"context": context},
         }

--- a/agents/budget_optimizer_agent.py
+++ b/agents/budget_optimizer_agent.py
@@ -9,32 +9,18 @@ class BudgetOptimizerAgent:
 
     def process(self, state: Dict[str, Any]) -> Dict[str, Any]:
         context = state.get("context", {}) or {}
-        amount_str = context.get("amount")
+        amount = context.get("amount")
 
-        try:
-            amount = float(amount_str) if amount_str else None
-        except ValueError:
-            amount = None
-
-        if amount is not None:
-            savings = amount * 0.5
-            investing = amount * 0.3
-            fun = amount - savings - investing
-            base = (
-                f"Allocate ${savings:.2f} to savings, ${investing:.2f} to investments, "
-                f"and ${fun:.2f} for discretionary spending."
-            )
-            result = generate_response(
-                f"Suggest a short budgeting tip based on: {base}"
-            )
-        else:
-            base = (
-                "Optimize by allocating 50% to savings, 30% to investments and 20% to discretionary spending."
-            )
-            result = generate_response(base)
+        prompt = (
+            "You are a budgeting expert. Provide a short recommendation for how "
+            "to allocate a user's disposable income. Include specific dollar "
+            "amounts if provided. Limit to two sentences.\nContext: "
+            f"{context}"
+        )
+        result = generate_response(prompt, max_tokens=80)
 
         return {
             "result": result,
             "confidence_score": 0.82,
-            "metadata": {"amount": amount},
+            "metadata": {"context": context},
         }

--- a/agents/explainer_agent.py
+++ b/agents/explainer_agent.py
@@ -1,6 +1,7 @@
 """Converts technical results into simple language."""
 
 from typing import Dict, Any
+from .openai_utils import generate_response
 
 
 class ExplainerAgent:
@@ -10,9 +11,11 @@ class ExplainerAgent:
         final_result = state.get("final_result", "")
 
         if final_result:
-            explanation = (
-                "In short, " + final_result.replace("Simulated", "we simulated")
+            prompt = (
+                "Explain the following in very simple language in one sentence:\n"
+                f"{final_result}"
             )
+            explanation = generate_response(prompt, max_tokens=60)
         else:
             explanation = "Unable to generate an explanation."
 

--- a/agents/openai_utils.py
+++ b/agents/openai_utils.py
@@ -1,9 +1,10 @@
 import os
+import json
 import openai
 
 
-def generate_response(prompt: str) -> str:
-    """Return a short completion from OpenAI if a key is available."""
+def generate_response(prompt: str, max_tokens: int = 60) -> str:
+    """Return a completion from OpenAI if a key is available."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         return "[OpenAI API key not set] " + prompt
@@ -12,8 +13,27 @@ def generate_response(prompt: str) -> str:
         completion = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=60,
+            max_tokens=max_tokens,
         )
         return completion.choices[0].message.content.strip()
     except Exception as e:
         return f"[OpenAI error: {e}]"
+
+
+def generate_json(prompt: str, max_tokens: int = 200) -> dict:
+    """Return a JSON dict parsed from an OpenAI completion."""
+    text = generate_response(prompt, max_tokens=max_tokens)
+    try:
+        return json.loads(text)
+    except Exception:
+        return {}
+
+
+def summarize_results(results: list[str], max_tokens: int = 120) -> str:
+    """Combine multiple responses into one coherent summary."""
+    joined = "\n".join(f"- {r}" for r in results if r)
+    prompt = (
+        "Summarize the following financial recommendations into a single, "
+        f"clear response:\n{joined}"
+    )
+    return generate_response(prompt, max_tokens=max_tokens)

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -1,6 +1,7 @@
 # agents/planner.py
 from typing import Dict, Any, List
 import re
+from .openai_utils import generate_json
 
 from dotenv import load_dotenv
 load_dotenv(override=True)
@@ -28,27 +29,48 @@ class PlannerAgent:
     
     def process(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """Analyzes query and determines routing strategy"""
-        user_input = state.get("input", "").lower()
-        
-        # Determine query type
-        query_type = self._classify_query(user_input)
-        
-        # Extract context and parameters
-        context = self._extract_context(user_input, query_type)
-        
-        # Determine if explanation is needed
-        requires_explanation = self._needs_explanation(user_input)
-        
-        # Extract simulation parameters if applicable
-        simulation_params = None
-        if query_type == "simulation":
-            simulation_params = self._extract_simulation_params(user_input)
-        
+        user_input = state.get("input", "")
+        existing_context = state.get("context", {}) or {}
+
+        prompt = (
+            "You are a financial assistant. Analyse the following user request "
+            "and return a JSON object with keys: query_type (life_event, "
+            "budget_optimization, investment_analysis, simulation, general), "
+            "context (dictionary of any amounts, timeframe as [number, unit], "
+            "risk_tolerance, goal, esg flag, include_holdings, include_expenses, "
+            "execute_plaid, override_fixed_expenses), requires_explanation "
+            "(true/false), and simulation_params (include scenario_type if the "
+            "request implies a scenario). Only output valid JSON.\nRequest: "
+            f"{user_input}"
+        )
+
+        data = generate_json(prompt)
+        if data:
+            ctx = data.get("context", {}) or {}
+            context = {**existing_context, **ctx}
+            return {
+                "query_type": data.get("query_type", "general"),
+                "context": context,
+                "requires_explanation": data.get("requires_explanation", False),
+                "simulation_params": data.get("simulation_params"),
+            }
+
+        # Fallback heuristic behaviour when OpenAI parsing fails
+        user_input_lower = user_input.lower()
+        query_type = self._classify_query(user_input_lower)
+        context = self._extract_context(user_input_lower, query_type)
+        context = {**existing_context, **context}
+        requires_explanation = self._needs_explanation(user_input_lower)
+        simulation_params = (
+            self._extract_simulation_params(user_input_lower)
+            if query_type == "simulation"
+            else None
+        )
         return {
             "query_type": query_type,
             "context": context,
             "requires_explanation": requires_explanation,
-            "simulation_params": simulation_params
+            "simulation_params": simulation_params,
         }
     
     def _classify_query(self, user_input: str) -> str:

--- a/agents/simulation_agent.py
+++ b/agents/simulation_agent.py
@@ -1,6 +1,7 @@
 """Simple scenario simulation logic."""
 
 from typing import Dict, Any
+from .openai_utils import generate_response
 
 
 class SimulationAgent:
@@ -13,17 +14,12 @@ class SimulationAgent:
 
         scenario = params.get("scenario_type", "generic")
 
-        if scenario == "job_loss":
-            desc = "Simulated six months of income loss"
-        elif scenario == "emergency":
-            desc = "Simulated emergency expense impact"
-        elif scenario == "market_downturn":
-            desc = "Simulated market downturn effect on portfolio"
-        else:
-            desc = "Simulated generic scenario"
-
-        if timeframe:
-            desc += f" over {timeframe[0]} {timeframe[1]}s"
+        prompt = (
+            "Briefly describe the financial impact of a "
+            f"{scenario} scenario. If a timeframe is provided include it.\n"
+            f"Timeframe: {timeframe}"
+        )
+        desc = generate_response(prompt, max_tokens=80)
 
         return {
             "result": desc,

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,54 @@
+from graph import graph
+
+
+def gather_profile():
+    print("Welcome to FinLife Navigator CLI")
+    name = input("Name (optional): ").strip()
+    risk = input("Risk tolerance (low/medium/high) [medium]: ").strip().lower() or "medium"
+    goal = input("Primary financial goal (optional): ").strip()
+    horizon = input("Time horizon in years (optional): ").strip()
+    timeframe = None
+    if horizon:
+        try:
+            timeframe = (int(horizon), "year")
+        except ValueError:
+            pass
+    return {
+        "name": name,
+        "risk_tolerance": risk,
+        "goal": goal or None,
+        "timeframe": timeframe,
+    }
+
+
+def run_cli():
+    profile = gather_profile()
+    print("\nType 'exit' to quit.\n")
+    while True:
+        user_input = input("You: ").strip()
+        if user_input.lower() in {"exit", "quit"}:
+            print("Goodbye!")
+            break
+        initial_state = {
+            "input": user_input,
+            "query_type": None,
+            "context": profile,
+            "intermediate_results": [],
+            "final_result": "",
+            "confidence_score": None,
+            "requires_explanation": False,
+            "simulation_params": None,
+        }
+        final_state = graph.invoke(initial_state)
+        output = final_state.get("final_result", "")
+        print(f"Assistant: {output}")
+        # Debug: show state if no result
+        if not output or output == "No results available":
+            print("Debug final state:", final_state)
+        if final_state.get("confidence_score") is not None:
+            print(f"(Confidence: {final_state['confidence_score']:.2f})")
+        print()
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/graph.py
+++ b/graph.py
@@ -1,6 +1,7 @@
 # graph.py
 from langgraph.graph import StateGraph, START, END
 from typing import TypedDict, List, Optional, Any
+from agents.openai_utils import summarize_results
 from agents.planner import PlannerAgent
 from agents.LifeEventAgent import LifeEventAgent
 from agents.budget_optimizer_agent import BudgetOptimizerAgent
@@ -192,12 +193,12 @@ class FinLifeNavigator:
     
     def _combine_results(self, results: List[dict]) -> str:
         """Intelligently combines results from multiple agents"""
-        combined = []
-        for result in results:
-            if result.get("result"):
-                combined.append(result["result"])
-        
-        return " | ".join(combined) if combined else "No results available"
+        texts = [r.get("result") for r in results if r.get("result")]
+        if not texts:
+            return "No results available"
+        if len(texts) == 1:
+            return texts[0]
+        return summarize_results(texts)
 
 # Create global instance
 navigator = FinLifeNavigator()


### PR DESCRIPTION
## Summary
- add helper to parse JSON responses from OpenAI
- replace heuristic routing in `PlannerAgent` with an OpenAI prompt
- generate life event, budgeting, investment, simulation and explanation text via OpenAI
- add interactive CLI
- fix merge artifact in `planner.py`
- clean up unused imports
- summarize multi-agent results with OpenAI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(works with placeholder output when `OPENAI_API_KEY` isn't set)*
- `echo -e 'medium\nretirement\n10\nexit\n' | python cli.py` *(fails: EOFError)*


------
https://chatgpt.com/codex/tasks/task_e_68449040e0348332b0c2eb1057ebff4d